### PR TITLE
Update README.md to avoid build fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import { JwtConfigService, JwtHttp } from 'angular2-jwt-refresh';
   providers: [{
     provide: JwtHttp,
     useFactory: getJwtHttp,
-    deps: [ Http ]
+    deps: [ Http, RequestOptions ]
   }]
 })
 export class AppModule {}


### PR DESCRIPTION
I updated my project, managed by angular-cli, to Angular 4.0.
After that, I encoutered a problem while building the project (ng build --prod). The problem was that the RequestOptions is not explicity injected in the getJwtHttp function in the providers annotation for AppModule.